### PR TITLE
Use local path, rather than href for a local src htmlDependency

### DIFF
--- a/R/tabler.R
+++ b/R/tabler.R
@@ -11,7 +11,7 @@ tablers_deps <- htmlDependency(
 tabler_custom_js <- htmlDependency(
   name = "tabler-bindings",
   version = "1.0.7",
-  src = c(href = "tabler"),
+  src = "tabler",
   package = "OSUICode",
   script = c(
     "input-bindings/navbarMenuBinding.js",


### PR DESCRIPTION
Matches changes in https://github.com/DivadNojnarg/outstanding-shiny-ui/issues/56

------------------

When running locally, it did not work. When running with `OSUICode`, it did work. 🤷 . At least it will be consistent with the book.