### PR TITLE
Only fire toast hidden event once

### DIFF
--- a/inst/tabler/tabler_toast_handler.js
+++ b/inst/tabler/tabler_toast_handler.js
@@ -5,7 +5,7 @@ $(function() {
     .toast('show');
 
     // add custom Shiny input to listen to the toast state
-    $(`#${message.id}`).on('hidden.bs.toast', function() {
+    $(`#${message.id}`).once('hidden.bs.toast', function() {
       Shiny.setInputValue(message.id, true, {priority: 'event'});
     });
   });


### PR DESCRIPTION
If the toast is fired multiple times on the same ID, then the handler will be fired multiples when a single toast id hides

```
❯❯ shinyApp(ui, server)
Listening on http://127.0.0.1:5043
NULL
(click)
[1] TRUE
(click)
[1] TRUE
[1] TRUE
(click)
[1] TRUE
[1] TRUE
[1] TRUE
(click)
[1] TRUE
[1] TRUE
[1] TRUE
[1] TRUE
(click)
[1] TRUE
[1] TRUE
[1] TRUE
[1] TRUE
[1] TRUE
```