### PR TITLE
Update `a[href=]` to `a[data-target=]`

### DIFF
--- a/inst/tabler/input-bindings/navbarMenuBinding.js
+++ b/inst/tabler/input-bindings/navbarMenuBinding.js
@@ -27,7 +27,7 @@ $(function() {
     setValue: function(el, value) {
       let hrefVal = '#' + value;
       let menuId = $(el).attr('id');
-      $(`#${menuId} a[href="${hrefVal}"]`).tab('show');
+      $(`#${menuId} a[data-target="${hrefVal}"]`).tab('show');
     },
     receiveMessage: function(el, data) {
       this.setValue(el, data);


### PR DESCRIPTION
Related: https://github.com/DivadNojnarg/outstanding-shiny-ui/issues/66#issuecomment-875601930

When testing locally on mac chrome, the href was `#`. But with the PR above, it makes sense to use `data-target` as that should be untouched.

Once merged, verify that chapter 20 crrry testing works as expected. (Failed when running `expect_equal(res5$result$value, res6$result$value)`)