### PR TITLE
shinyMobile: Move `taphold=` to `touch(tapHold=)`

### DIFF
--- a/inst/shinyMobile/simple/app.R
+++ b/inst/shinyMobile/simple/app.R
@@ -21,7 +21,9 @@ ui <- f7_page(
   options = list(
     theme = "ios",
     version = "1.0.0",
-    taphold = TRUE,
+    touch = list(
+      tapHold = TRUE
+    ),
     color = "#42f5a1",
     filled = TRUE,
     dark = TRUE


### PR DESCRIPTION
Matches logic in: https://github.com/DivadNojnarg/outstanding-shiny-ui-code/blob/e9d175706d5e7f192d67c63ac2c3ed89e6da5a6d/srcjs/helpers_theme.js#L4